### PR TITLE
vendor Hugo modules and flatten public to remove symlinks

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -45,6 +45,9 @@ jobs:
         id: pages
         uses: actions/configure-pages@v4
 
+      - name: Vendor Hugo modules
+        run: hugo mod vendor
+
       - name: Install Node.js dependencies
         run: |
           [[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true
@@ -68,10 +71,9 @@ jobs:
           echo "---- listing public/ files ----"
           find public -type f -exec ls -l {} \;
 
-      - name: Flatten public into public-flat (dereference symlinks)
+      - name: Flatten public into public-flat (dereference any remaining symlinks)
         run: |
           rm -rf public-flat
-          # -a = archive mode, -L = follow symlinks
           rsync -aL public/ public-flat/
 
       - name: Upload artifact


### PR DESCRIPTION
- Adiciona `hugo mod vendor` antes do build para incorporar temas e módulos sem links
- Usa `rsync -aL` para criar `public-flat/`, garantindo que o artifact não contenha symlinks
- Atualiza upload para enviar apenas `public-flat/`