### PR TITLE
Retorna a upload-pages-artifact@v2 (empacota sem links) mantendo Hugo 0.148.1

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -25,100 +25,46 @@ jobs:
       HUGO_VERSION: 0.148.1
 
     steps:
-    # ---------------------------------------------------------------------
-    # SETUP
-    # ---------------------------------------------------------------------
-    - name: Install Hugo
-      run: |
-        wget -O ${{ runner.temp }}/hugo.deb \
-          "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
-        sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      # ---------- Setup ----------
+      - name: Install Hugo
+        run: |
+          wget -O ${{ runner.temp }}/hugo.deb \
+            "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb"
+          sudo dpkg -i ${{ runner.temp }}/hugo.deb
 
-    - name: Install Dart Sass
-      run: sudo snap install dart-sass
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
 
-    - name: Checkout repo (with submodules)
-      uses: actions/checkout@v4
-      with:
-        submodules: recursive
-        fetch-depth: 0
+      - name: Checkout repo (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
-    - name: Setup Pages
-      id: pages
-      uses: actions/configure-pages@v4
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v4
 
-    - name: Vendor Hugo modules (avoid build‑time links)
-      run: hugo mod vendor
+      - name: Vendor Hugo modules
+        run: hugo mod vendor
 
-    - name: Install Node deps (if any)
-      run: |
-        [[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true
+      - name: Install Node deps (if any)
+        run: |
+          [[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true
 
-    # ---------------------------------------------------------------------
-    # BUILD
-    # ---------------------------------------------------------------------
-    - name: Build with Hugo
-      env:
-        HUGO_ENVIRONMENT: production
-        HUGO_ENV: production
-      run: |
-        hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
+      # ---------- Build ----------
+      - name: Build with Hugo
+        env:
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
-    # ---------------------------------------------------------------------
-    # DIAGNOSTICS ─ BEFORE FLATTEN
-    # ---------------------------------------------------------------------
-    - name: List residual symlinks in public/ (fail if any)
-      run: |
-        echo "=== Symlinks in public/ BEFORE flatten ==="
-        if find public -type l | tee /dev/stderr | grep -q .; then
-          echo "❌ Symlinks ainda presentes." && exit 1
-        else
-          echo "✔ Nenhum symlink em public/"
-        fi
-
-    - name: List residual hard‑links in public/ (fail if any)
-      run: |
-        echo "=== Hard‑links in public/ BEFORE flatten ==="
-        if find public -type f -links +1 | tee /dev/stderr | grep -q .; then
-          echo "❌ Hard‑links ainda presentes." && exit 1
-        else
-          echo "✔ Nenhum hard‑link em public/"
-        fi
-
-    # ---------------------------------------------------------------------
-    # FLATTEN (dereference ALL links)
-    # ---------------------------------------------------------------------
-    - name: Flatten public → public-flat (tar ‑ch --hard-dereference)
-      run: |
-        rm -rf public-flat
-        mkdir public-flat
-        tar -C public --hard-dereference -chf - . | tar -C public-flat -xf -
-
-    # ---------------------------------------------------------------------
-    # DIAGNOSTICS ─ AFTER FLATTEN
-    # ---------------------------------------------------------------------
-    - name: Verify links in public-flat/ (must be zero)
-      run: |
-        echo "=== Symlinks in public-flat/ ==="
-        find public-flat -type l
-        echo "=== Hard‑links in public-flat/ ==="
-        find public-flat -type f -links +1
-        if find public-flat -type l -o -type f -links +1 | grep -q .; then
-          echo "❌ Ainda há links em public-flat/" && exit 1
-        else
-          echo "✔ public-flat/ livre de links"
-        fi
-        echo "=== Artifact size ==="
-        du -sh public-flat
-
-    # ---------------------------------------------------------------------
-    # UPLOAD ARTIFACT
-    # ---------------------------------------------------------------------
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: github-pages
-        path: public-flat
+      # ---------- Upload artifact (Pages‑aware) ----------
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: public       # ← diretório gerado pelo Hugo
 
   deploy:
     needs: build


### PR DESCRIPTION
- Volta ao empacotador usado na versão que funcionava
- Mantém vendorização de módulos e build com Hugo 0.148.1